### PR TITLE
ENG-11977 Fix logic in getModel to recognize typeless object schemas

### DIFF
--- a/src/openApi/v3/parser/getModel.spec.ts
+++ b/src/openApi/v3/parser/getModel.spec.ts
@@ -1,0 +1,23 @@
+import { OpenApi } from '../interfaces/OpenApi';
+import { OpenApiSchema } from '../interfaces/OpenApiSchema';
+import { getModel } from './getModel';
+
+describe('getModel', () => {
+    it('should get an object model when type is missing but properties exist', () => {
+        const openApi: OpenApi = {
+            openapi: '3.0.1',
+            info: { title: 'OpenApi Test', version: '0.1.0' },
+            paths: {},
+        };
+        const definition: OpenApiSchema = {
+            properties: {
+                data: {
+                    type: 'string',
+                },
+            },
+        };
+
+        const model = getModel(openApi, definition);
+        expect(model.properties[0].name).toBe('data');
+    });
+});

--- a/src/openApi/v3/parser/getModel.ts
+++ b/src/openApi/v3/parser/getModel.ts
@@ -149,7 +149,7 @@ export const getModel = (
         return model;
     }
 
-    if (definition.type === 'object') {
+    if (definition.type === 'object' || definition.properties) {
         if (definition.properties) {
             model.export = 'interface';
             model.type = 'any';


### PR DESCRIPTION
### Description

The api client generated from our openapi.json spec file (generated by the backend) had incomplete return types for some methods. 
This was due to a bug in the `getModel` method, whereby if a schema definition passed in had no `type` property, but was in fact an `object` (had `properties` which implies an object), then it would "fall through" all the conditions and return an "empty" model. There was no condition to capture this edge case. 

As far as I can tell, the `type` property _is optional,_ according to the OpenAPI spec, and the `properties` attribute is used to describe only objects, so its presence allows you to safely assume an object type. This logic was added to the existing object predicate, and a unit test was added to assert it. 

### Test Plan

- Ensure all of this repos "checks" still pass:
  - `npm install`
  - `npm run build`
  - `npm run validate`
  - `npm run test`
  - `npm run eslint`
